### PR TITLE
correct bin rescaling when bin edges are integers

### DIFF
--- a/TwoDAlphabet/alphawrap.py
+++ b/TwoDAlphabet/alphawrap.py
@@ -322,8 +322,8 @@ class ParametricFunction(Generic2D):
         y_range = self.binning.ybinList[-1] - y_min
         
         # Remap to [-1,1]
-        x_center_mapped = float((x_center - x_min))/x_range #float cast prevents returning zero if bin edges are ints
-        y_center_mapped = float((y_center - y_min))/y_range
+        x_center_mapped = float(x_center - x_min)/x_range #float cast prevents returning zero if bin edges are ints
+        y_center_mapped = float(y_center - y_min)/y_range
 
         return x_center_mapped,y_center_mapped
 

--- a/TwoDAlphabet/alphawrap.py
+++ b/TwoDAlphabet/alphawrap.py
@@ -322,8 +322,8 @@ class ParametricFunction(Generic2D):
         y_range = self.binning.ybinList[-1] - y_min
         
         # Remap to [-1,1]
-        x_center_mapped = (x_center - x_min)/x_range
-        y_center_mapped = (y_center - y_min)/y_range
+        x_center_mapped = float((x_center - x_min))/x_range #float cast prevents returning zero if bin edges are ints
+        y_center_mapped = float((y_center - y_min))/y_range
 
         return x_center_mapped,y_center_mapped
 


### PR DESCRIPTION
I ran into an issue when explicitly defining bins in config file (e.g. "BINS":[ 50, 55,...,150]). Bin edges were treated as integers and x/y_center_mapped returned zero (division of two integers)