### PR TITLE
setFuncParam() bug fix, added functionality

### DIFF
--- a/TwoDAlphabet/alphawrap.py
+++ b/TwoDAlphabet/alphawrap.py
@@ -328,10 +328,10 @@ class ParametricFunction(Generic2D):
         return x_center_mapped,y_center_mapped
 
     def setFuncParam(self,parIdx,value):
-        '''Set the value of a given 
+        '''Set the value of a given ROOT.RooRealVar object within a ParametricFunction
 
         Args:
-            parIdx (int,str): Parameter index to access.
+            parIdx (int,str): Parameter index to access, or parameter name.
             value (float): Value to assign.
 
         Raises:
@@ -342,8 +342,14 @@ class ParametricFunction(Generic2D):
         '''
         parfound = False
         for i,n in enumerate(self.nuisances):
-            if n['name'].endswith('_par%s'%parIdx):
-                self.nuisances[i].setVal(value)
+            # user supplies full parameter name, e.g. 'Background_CR_rpfT_par0'
+            if n['name'] == parIdx:
+                self.nuisances[i]['obj'].setVal(value)
+                parfound = True
+                break
+            # user supplies only parameter index, e.g. '0', 0
+            elif n['name'].endswith('_par%s'%parIdx):   
+                self.nuisances[i]['obj'].setVal(value)
                 parfound = True
                 break
         if parfound == False:

--- a/TwoDAlphabet/alphawrap.py
+++ b/TwoDAlphabet/alphawrap.py
@@ -190,7 +190,7 @@ class Generic2D(object):
             RooFormulaVar: RooFit object for the requested bin.
         '''
         if c == '': # using a global xbin that needs to be translated
-            c, xbin = self.binning.xcatFromGlobal(xbin)
+            xbin, c = self.binning.xcatFromGlobal(xbin)
         formula_name = '%s_bin_%s-%s'%(self.name+'_'+c,xbin,ybin)
         return self.binVars[formula_name]
             


### PR DESCRIPTION
The `setFuncParam()` method for the `ParametricFunction` class had a bug wherein, if the user supplied the rpf parameter index in any form, the function would fail because the RooRealVar `setVal()` method was being applied to the ParamtericFunction's `nuisances` list, and not the actual RooRealVar object. I fixed this by ensuring that the method was applied to the object, not the list. 

In addition, I added functionality for the user to provide the full parameter name, for example `Background_CR_rpfT_par0`. I suppose 2DAlphabet generates these parameters manually with `_parX` appended to the parameter name, but perhaps this could be useful if for some reason the parameter names are of a different form. Feel free to remove that part :)